### PR TITLE
Rename the datasetfilter query as this was using a strange convention…

### DIFF
--- a/src/generated/graphql.schema.json
+++ b/src/generated/graphql.schema.json
@@ -19,13 +19,9 @@
                 "name": "q",
                 "description": "",
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null
               },
@@ -101,13 +97,9 @@
                 "name": "q",
                 "description": "",
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null
               },
@@ -142,13 +134,9 @@
                 "name": "q",
                 "description": "",
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null
               },
@@ -183,13 +171,9 @@
                 "name": "q",
                 "description": "",
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null
               },
@@ -217,20 +201,16 @@
             "deprecationReason": null
           },
           {
-            "name": "getDatasetFilters",
+            "name": "datasetFilters",
             "description": "",
             "args": [
               {
                 "name": "q",
                 "description": "",
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
                 },
                 "defaultValue": null
               }

--- a/src/generated/graphql.ts
+++ b/src/generated/graphql.ts
@@ -150,11 +150,11 @@ export type Query = {
   datasetSearch?: Maybe<DatasetSearchResult>
   publicationSearch?: Maybe<CmsSearchResult>
   specialSearch?: Maybe<CmsSearchResult>
-  getDatasetFilters?: Maybe<DatasetFiltersResult>
+  datasetFilters?: Maybe<DatasetFiltersResult>
 }
 
 export type QueryArticleSearchArgs = {
-  q: Scalars['String']
+  q?: Maybe<Scalars['String']>
   input: CmsSearchInput
 }
 
@@ -164,22 +164,22 @@ export type QueryDataSearchArgs = {
 }
 
 export type QueryDatasetSearchArgs = {
-  q: Scalars['String']
+  q?: Maybe<Scalars['String']>
   input: DatasetSearchInput
 }
 
 export type QueryPublicationSearchArgs = {
-  q: Scalars['String']
+  q?: Maybe<Scalars['String']>
   input: CmsSearchInput
 }
 
 export type QuerySpecialSearchArgs = {
-  q: Scalars['String']
+  q?: Maybe<Scalars['String']>
   input: CmsSearchInput
 }
 
-export type QueryGetDatasetFiltersArgs = {
-  q: Scalars['String']
+export type QueryDatasetFiltersArgs = {
+  q?: Maybe<Scalars['String']>
 }
 
 export type Results = DatasetSearchResultType | CmsSearchResultType | DataSearchResultType
@@ -475,7 +475,7 @@ export type QueryResolvers<
     Maybe<ResolversTypes['CMSSearchResult']>,
     ParentType,
     ContextType,
-    RequireFields<QueryArticleSearchArgs, 'q' | 'input'>
+    RequireFields<QueryArticleSearchArgs, 'input'>
   >
   dataSearch?: Resolver<
     Maybe<ResolversTypes['DataSearchResult']>,
@@ -487,25 +487,25 @@ export type QueryResolvers<
     Maybe<ResolversTypes['DatasetSearchResult']>,
     ParentType,
     ContextType,
-    RequireFields<QueryDatasetSearchArgs, 'q' | 'input'>
+    RequireFields<QueryDatasetSearchArgs, 'input'>
   >
   publicationSearch?: Resolver<
     Maybe<ResolversTypes['CMSSearchResult']>,
     ParentType,
     ContextType,
-    RequireFields<QueryPublicationSearchArgs, 'q' | 'input'>
+    RequireFields<QueryPublicationSearchArgs, 'input'>
   >
   specialSearch?: Resolver<
     Maybe<ResolversTypes['CMSSearchResult']>,
     ParentType,
     ContextType,
-    RequireFields<QuerySpecialSearchArgs, 'q' | 'input'>
+    RequireFields<QuerySpecialSearchArgs, 'input'>
   >
-  getDatasetFilters?: Resolver<
+  datasetFilters?: Resolver<
     Maybe<ResolversTypes['DatasetFiltersResult']>,
     ParentType,
     ContextType,
-    RequireFields<QueryGetDatasetFiltersArgs, 'q'>
+    QueryDatasetFiltersArgs
   >
 }
 

--- a/src/graphql/graphql.schema.ts
+++ b/src/graphql/graphql.schema.ts
@@ -135,12 +135,12 @@ const schema = gql`
   }
 
   type Query {
-    articleSearch(q: String!, input: CMSSearchInput!): CMSSearchResult
+    articleSearch(q: String, input: CMSSearchInput!): CMSSearchResult
     dataSearch(q: String!, input: DataSearchInput!): DataSearchResult
-    datasetSearch(q: String!, input: DatasetSearchInput!): DatasetSearchResult
-    publicationSearch(q: String!, input: CMSSearchInput!): CMSSearchResult
-    specialSearch(q: String!, input: CMSSearchInput!): CMSSearchResult
-    getDatasetFilters(q: String!): DatasetFiltersResult
+    datasetSearch(q: String, input: DatasetSearchInput!): DatasetSearchResult
+    publicationSearch(q: String, input: CMSSearchInput!): CMSSearchResult
+    specialSearch(q: String, input: CMSSearchInput!): CMSSearchResult
+    datasetFilters(q: String): DatasetFiltersResult
   }
 `
 

--- a/src/graphql/resolvers/search/cms/filters.ts
+++ b/src/graphql/resolvers/search/cms/filters.ts
@@ -1,5 +1,5 @@
 import fetch from 'node-fetch'
-import { formatThemeFilters } from './normalize'
+import { formatThemeFilters, formatDateFilters } from './normalize'
 import withCache from '../../../utils/memoryCache'
 
 interface FilterCount {
@@ -24,7 +24,9 @@ export default async (filterCount: FilterCount): Promise<any> => {
     const themeTaxonomy: any = await Promise.resolve(themeTaxonomyCached())
     const themeFilters: any = formatThemeFilters(themeTaxonomy, filterCount.theme)
 
-    filters = [themeFilters]
+    const dateFilters: any = formatDateFilters()
+
+    filters = [themeFilters, dateFilters]
   } catch (e) {
     console.warn(e)
   }

--- a/src/graphql/resolvers/search/index.ts
+++ b/src/graphql/resolvers/search/index.ts
@@ -10,6 +10,6 @@ export default {
     datasetSearch,
     publicationSearch,
     specialSearch,
-    getDatasetFilters: datasetFilters,
+    datasetFilters,
   },
 }


### PR DESCRIPTION
…, q (search term) is no longer required on queries that can have an empty string as value for q