### PR TITLE
Send an empty query string to the openapi when no searchterm has been…

### DIFF
--- a/src/graphql/resolvers/search/datasets/filters.ts
+++ b/src/graphql/resolvers/search/datasets/filters.ts
@@ -9,7 +9,7 @@ const week = 60 * 60 * 24 * 7
 export const openApiCached = async () =>
   withCache('openApi', fetch(DCAT_ENDPOINTS['openapi']), week)
 
-export default async (_: any, { q }: any): Promise<any> => {
+export default async (_: any, { q = '' }: any): Promise<any> => {
   let filters
   try {
     const urlQuery = new URLSearchParams({ q }).toString()


### PR DESCRIPTION
… entered