### PR TITLE
Fix for invalid maatschappelijke_activiteit config value

### DIFF
--- a/src/graphql/search/data/config.ts
+++ b/src/graphql/search/data/config.ts
@@ -18,7 +18,7 @@ export enum DataType {
   Buildings = 'panden',
   Regions = 'gebieden',
   Branches = 'vestigingen',
-  SocialActivity = 'maatschappelijke_activiteit',
+  SocialActivity = 'maatschappelijkeactiviteit',
   CadastralProperties = 'kadastrale_objecten',
   CadastralSubject = 'kadastrale_subjecten',
   MeasuringBolt = 'meetbouten',


### PR DESCRIPTION
This could have also been fixed by changing 'maatschappelijkeactiviteit' in the `.env` file, however, this way would also require one change in data-verkenner (an error is thrown via `DataIcon` as that expects `maatschappelijkeactiviteit`)